### PR TITLE
Feat: Added territory rendering via journeyMap API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,6 +269,16 @@ tasks.named('jar', Jar).configure {
 // tasks.named('publish').configure {
 //     dependsOn 'reobfJar'
 // }
+tasks.register('prepareDevJar', Copy) {
+    dependsOn 'reobfJar'
+
+    from layout.buildDirectory.dir("libs")
+    include "${mod_id}-${version}.jar"
+
+    into layout.buildDirectory.dir("reobfJar")
+    rename { "${mod_id}-dev.jar" }
+}
+build.dependsOn prepareDevJar
 
 // Example configuration to allow publishing using the maven-publish plugin
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,12 @@ repositories {
 
     // DevAuth
     maven { url = "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
+
+    // JourneyMap-API
+    maven {
+        name = "JourneyMap (Public)"
+        url = "https://jm.gserv.me/repository/maven-public/"
+    }
 }
 
 dependencies {
@@ -217,6 +223,9 @@ dependencies {
 
     // Jade
     implementation(fg.deobf("maven.modrinth:jade:11.13.2+forge"))
+
+    // JourneyMap-API
+    compileOnly(fg.deobf("info.journeymap:journeymap-api:1.20-1.9-SNAPSHOT"))
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/client/StyleConverter.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/client/StyleConverter.java
@@ -1,0 +1,20 @@
+package com.gdd.ptdyeplus.features.territories.client;
+
+import com.gdd.ptdyeplus.features.territories.common.TerritoryStyle;
+import journeymap.client.api.model.ShapeProperties;
+
+public class StyleConverter {
+    public static ShapeProperties toShapeProperties(TerritoryStyle style) {
+        return new ShapeProperties()
+            .setStrokeColor(style.strokeColor())
+            .setFillColor(style.fillColor())
+            .setStrokeOpacity(style.strokeOpacity())
+            .setFillOpacity(style.fillOpacity())
+            .setStrokeWidth(style.strokeWidth())
+            .setImageLocation(style.imageLocation())
+            .setTexturePositionX(style.texturePositionX())
+            .setTexturePositionY(style.texturePositionY())
+            .setTextureScaleX(style.textureScaleX())
+            .setTextureScaleY(style.textureScaleY());
+    }
+}

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/client/TerritoryConverter.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/client/TerritoryConverter.java
@@ -1,9 +1,15 @@
 package com.gdd.ptdyeplus.features.territories.client;
 
+import com.gdd.ptdyeplus.features.territories.common.IslandGeometry;
 import com.gdd.ptdyeplus.features.territories.common.TerritoryStyle;
+import journeymap.client.api.model.MapPolygon;
+import journeymap.client.api.model.MapPolygonWithHoles;
 import journeymap.client.api.model.ShapeProperties;
+import net.minecraft.core.BlockPos;
 
-public class StyleConverter {
+import java.util.List;
+
+public class TerritoryConverter {
     public static ShapeProperties toShapeProperties(TerritoryStyle style) {
         return new ShapeProperties()
             .setStrokeColor(style.strokeColor())
@@ -16,5 +22,22 @@ public class StyleConverter {
             .setTexturePositionY(style.texturePositionY())
             .setTextureScaleX(style.textureScaleX())
             .setTextureScaleY(style.textureScaleY());
+    }
+
+    public static MapPolygonWithHoles toMapPolygon(IslandGeometry island) {
+        return new MapPolygonWithHoles(
+            convertHull(island.hull()),
+            convertHoles(island.holes())
+        );
+    }
+
+    private static MapPolygon convertHull(List<BlockPos> points) {
+        return new MapPolygon(points);
+    }
+
+    private static List<MapPolygon> convertHoles(List<List<BlockPos>> holeList) {
+        if (holeList == null)
+            return null;
+        return holeList.stream().map(MapPolygon::new).toList();
     }
 }

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/client/TerritoryNetworkHandler.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/client/TerritoryNetworkHandler.java
@@ -1,0 +1,61 @@
+package com.gdd.ptdyeplus.features.territories.client;
+
+import com.gdd.ptdyeplus.PTDyePlus;
+import com.gdd.ptdyeplus.features.territories.common.TerritoryGeometrySyncPacket;
+import com.gdd.ptdyeplus.features.territories.common.TerritoryStyleSyncPacket;
+import com.gdd.ptdyeplus.journeymap.TerritoryOverlay;
+import journeymap.client.api.IClientAPI;
+import journeymap.client.api.model.ShapeProperties;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class TerritoryNetworkHandler {
+
+    private static final Map<UUID, TerritoryOverlay> CACHE = new HashMap<>();
+
+    public static TerritoryOverlay get(UUID territoryID) {
+        return CACHE.computeIfAbsent(territoryID, TerritoryOverlay::new);
+    }
+
+    public static void onAPIReady(IClientAPI jmAPI) {
+        TerritoryOverlay.updateAPI(jmAPI);
+        for (TerritoryOverlay overlay : CACHE.values()) {
+            try {
+                overlay.refreshOverlay();
+            } catch (Exception e) {
+                PTDyePlus.LOGGER.warn("Failed to initial-draw territory ({})", overlay.getTerritoryId(), e);
+            }
+        }
+    }
+
+    public static void handleGeometry(TerritoryGeometrySyncPacket packet, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        context.enqueueWork(() -> {
+            TerritoryOverlay territoryOverlay = get(packet.territoryId());
+            try {
+                territoryOverlay.updateGeometry(packet.geometries());
+            } catch (Exception e) {
+                PTDyePlus.LOGGER.warn("Failed to update geometry for territory ({})", packet.territoryId(), e);
+            }
+        });
+        context.setPacketHandled(true);
+    }
+
+    public static void handleStyle(TerritoryStyleSyncPacket packet, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        context.enqueueWork(() -> {
+            TerritoryOverlay territoryOverlay = get(packet.territoryId());
+            try {
+                ShapeProperties shapeProperties = StyleConverter.toShapeProperties(packet.style());
+                territoryOverlay.updateStyle(shapeProperties);
+            } catch (Exception e) {
+                PTDyePlus.LOGGER.warn("Failed to update style for territory ({})", packet.territoryId(), e);
+            }
+        });
+        context.setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/client/TerritoryNetworkHandler.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/client/TerritoryNetworkHandler.java
@@ -37,7 +37,6 @@ public class TerritoryNetworkHandler {
         context.enqueueWork(() -> {
             TerritoryOverlay territoryOverlay = get(packet.territoryId());
             try {
-
                 territoryOverlay.updateGeometry(packet.geometries());
             } catch (Exception e) {
                 PTDyePlus.LOGGER.warn("Failed to update geometry for territory ({})", packet.territoryId(), e);

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/client/TerritoryNetworkHandler.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/client/TerritoryNetworkHandler.java
@@ -37,6 +37,7 @@ public class TerritoryNetworkHandler {
         context.enqueueWork(() -> {
             TerritoryOverlay territoryOverlay = get(packet.territoryId());
             try {
+
                 territoryOverlay.updateGeometry(packet.geometries());
             } catch (Exception e) {
                 PTDyePlus.LOGGER.warn("Failed to update geometry for territory ({})", packet.territoryId(), e);
@@ -50,7 +51,7 @@ public class TerritoryNetworkHandler {
         context.enqueueWork(() -> {
             TerritoryOverlay territoryOverlay = get(packet.territoryId());
             try {
-                ShapeProperties shapeProperties = StyleConverter.toShapeProperties(packet.style());
+                ShapeProperties shapeProperties = TerritoryConverter.toShapeProperties(packet.style());
                 territoryOverlay.updateStyle(shapeProperties);
             } catch (Exception e) {
                 PTDyePlus.LOGGER.warn("Failed to update style for territory ({})", packet.territoryId(), e);

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/common/Edge.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/common/Edge.java
@@ -3,11 +3,4 @@ package com.gdd.ptdyeplus.features.territories.common;
 import net.minecraft.core.BlockPos;
 
 public record Edge(BlockPos p1, BlockPos p2) {
-    public Edge {
-        if (p1.getX() > p2.getX() || (p1.getX() == p2.getX() && p1.getZ() > p2.getZ())) {
-            BlockPos temp = p1;
-            p1 = p2;
-            p2 = temp;
-        }
-    }
 }

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/common/Edge.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/common/Edge.java
@@ -1,0 +1,13 @@
+package com.gdd.ptdyeplus.features.territories.common;
+
+import net.minecraft.core.BlockPos;
+
+public record Edge(BlockPos p1, BlockPos p2) {
+    public Edge {
+        if (p1.getX() > p2.getX() || (p1.getX() == p2.getX() && p1.getZ() > p2.getZ())) {
+            BlockPos temp = p1;
+            p1 = p2;
+            p2 = temp;
+        }
+    }
+}

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/common/IslandGeometry.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/common/IslandGeometry.java
@@ -1,27 +1,8 @@
 package com.gdd.ptdyeplus.features.territories.common;
 
-import journeymap.client.api.model.MapPolygon;
-import journeymap.client.api.model.MapPolygonWithHoles;
 import net.minecraft.core.BlockPos;
 
 import java.util.List;
 
 public record IslandGeometry(List<BlockPos> hull, List<List<BlockPos>> holes) {
-
-    public MapPolygonWithHoles toMapPolygon() {
-        return new MapPolygonWithHoles(
-            convertHull(this.hull),
-            convertHoles(this.holes)
-        );
-    }
-
-    private MapPolygon convertHull(List<BlockPos> points) {
-        return new MapPolygon(points);
-    }
-
-    private List<MapPolygon> convertHoles(List<List<BlockPos>> holeList) {
-        if (holeList == null)
-            return null;
-        return holeList.stream().map(MapPolygon::new).toList();
-    }
 }

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/common/IslandGeometry.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/common/IslandGeometry.java
@@ -1,0 +1,27 @@
+package com.gdd.ptdyeplus.features.territories.common;
+
+import journeymap.client.api.model.MapPolygon;
+import journeymap.client.api.model.MapPolygonWithHoles;
+import net.minecraft.core.BlockPos;
+
+import java.util.List;
+
+public record IslandGeometry(List<BlockPos> hull, List<List<BlockPos>> holes) {
+
+    public MapPolygonWithHoles toMapPolygon() {
+        return new MapPolygonWithHoles(
+            convertHull(this.hull),
+            convertHoles(this.holes)
+        );
+    }
+
+    private MapPolygon convertHull(List<BlockPos> points) {
+        return new MapPolygon(points);
+    }
+
+    private List<MapPolygon> convertHoles(List<List<BlockPos>> holeList) {
+        if (holeList == null)
+            return null;
+        return holeList.stream().map(MapPolygon::new).toList();
+    }
+}

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/common/TerritoryGeometrySyncPacket.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/common/TerritoryGeometrySyncPacket.java
@@ -1,0 +1,35 @@
+package com.gdd.ptdyeplus.features.territories.common;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public record TerritoryGeometrySyncPacket(UUID territoryId, List<IslandGeometry> geometries) {
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeUUID(territoryId);
+
+        buf.writeCollection(geometries, (buffer, island) -> {
+            buffer.writeCollection(island.hull(), FriendlyByteBuf::writeBlockPos);
+            buffer.writeCollection(island.holes(), (innerBuf, hole) -> {
+                innerBuf.writeCollection(hole, FriendlyByteBuf::writeBlockPos);
+            });
+        });
+    }
+
+    public static TerritoryGeometrySyncPacket decode(FriendlyByteBuf buf) {
+        UUID id = buf.readUUID();
+        List<IslandGeometry> geometries = buf.readCollection(ArrayList::new, buffer -> {
+            List<BlockPos> hull = buffer.readCollection(ArrayList::new, FriendlyByteBuf::readBlockPos);
+
+            List<List<BlockPos>> holes = buffer.readCollection(ArrayList::new, innerBuf ->
+                innerBuf.readCollection(ArrayList::new, FriendlyByteBuf::readBlockPos)
+            );
+
+            return new IslandGeometry(hull, holes);
+        });
+        return new TerritoryGeometrySyncPacket(id, geometries);
+    }
+}

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/common/TerritoryStyle.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/common/TerritoryStyle.java
@@ -1,0 +1,92 @@
+package com.gdd.ptdyeplus.features.territories.common;
+
+import net.minecraft.resources.ResourceLocation;
+
+public record TerritoryStyle(
+    int strokeColor,
+    int fillColor,
+    float strokeOpacity,
+    float fillOpacity,
+    float strokeWidth,
+    ResourceLocation imageLocation,
+    double texturePositionX,
+    double texturePositionY,
+    double textureScaleX,
+    double textureScaleY
+) {
+    public static class Builder {
+        private int strokeColor = 0;
+        private int fillColor = 0;
+        private float strokeOpacity = 1.0f;
+        private float fillOpacity = 0.5f;
+        private float strokeWidth = 2.0f;
+        private ResourceLocation imageLocation = null;
+        private double texturePositionX = 0.0d;
+        private double texturePositionY = 0.0d;
+        private double textureScaleX = 1.0d;
+        private double textureScaleY = 1.0d;
+
+        public TerritoryStyle build() {
+            return new TerritoryStyle(strokeColor, fillColor, strokeOpacity, fillOpacity, strokeWidth,
+                imageLocation, texturePositionX, texturePositionY, textureScaleX, textureScaleY);
+        }
+
+        public Builder color(int color) {
+            this.strokeColor = color;
+            this.fillColor = color;
+            return this;
+        }
+
+        public Builder opacity(float opacity) {
+            this.fillOpacity = opacity;
+            return this;
+        }
+
+        public Builder strokeColor(int strokeColor) {
+            this.strokeColor = strokeColor;
+            return this;
+        }
+
+        public Builder fillColor(int fillColor) {
+            this.fillColor = fillColor;
+            return this;
+        }
+
+        public Builder strokeOpacity(float strokeOpacity) {
+            this.strokeOpacity = strokeOpacity;
+            return this;
+        }
+
+        public Builder fillOpacity(float fillOpacity) {
+            this.fillOpacity = fillOpacity;
+            return this;
+        }
+
+        public Builder strokeWidth(float strokeWidth) {
+            this.strokeWidth = strokeWidth;
+            return this;
+        }
+
+        public Builder imageLocation(ResourceLocation imageLocation) {
+            this.imageLocation = imageLocation;
+            return this;
+        }
+
+        public Builder imageLocation(String imageLocation) {
+            this.imageLocation = ResourceLocation.parse(imageLocation);
+            return this;
+        }
+
+        public Builder texturePosition(double x, double y) {
+            this.texturePositionX = x;
+            this.texturePositionY = y;
+            return this;
+        }
+
+        public Builder textureScale(double x, double y) {
+            this.textureScaleX = x;
+            this.textureScaleY = y;
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/common/TerritoryStyleSyncPacket.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/common/TerritoryStyleSyncPacket.java
@@ -1,0 +1,39 @@
+package com.gdd.ptdyeplus.features.territories.common;
+
+import net.minecraft.network.FriendlyByteBuf;
+
+import java.util.UUID;
+
+public record TerritoryStyleSyncPacket(UUID territoryId, TerritoryStyle style) {
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeUUID(territoryId);
+
+        buf.writeInt(style.strokeColor());
+        buf.writeInt(style.fillColor());
+        buf.writeFloat(style.strokeOpacity());
+        buf.writeFloat(style.fillOpacity());
+        buf.writeFloat(style.strokeWidth());
+        buf.writeResourceLocation(style.imageLocation());
+        buf.writeDouble(style.texturePositionX());
+        buf.writeDouble(style.texturePositionY());
+        buf.writeDouble(style.textureScaleX());
+        buf.writeDouble(style.textureScaleY());
+    }
+
+    public static TerritoryStyleSyncPacket decode(FriendlyByteBuf buf) {
+        UUID id = buf.readUUID();
+
+        TerritoryStyle style = new TerritoryStyle.Builder()
+            .strokeColor(buf.readInt())
+            .fillColor(buf.readInt())
+            .strokeOpacity(buf.readFloat())
+            .fillOpacity(buf.readFloat())
+            .strokeWidth(buf.readFloat())
+            .imageLocation(buf.readResourceLocation())
+            .texturePosition(buf.readDouble(), buf.readDouble())
+            .textureScale(buf.readDouble(), buf.readDouble())
+            .build();
+
+        return new TerritoryStyleSyncPacket(id, style);
+    }
+}

--- a/src/main/java/com/gdd/ptdyeplus/features/territories/server/TerritoryManager.java
+++ b/src/main/java/com/gdd/ptdyeplus/features/territories/server/TerritoryManager.java
@@ -1,0 +1,243 @@
+package com.gdd.ptdyeplus.features.territories.server;
+
+import com.gdd.ptdyeplus.features.territories.common.Edge;
+import com.gdd.ptdyeplus.features.territories.common.IslandGeometry;
+import com.gdd.ptdyeplus.features.territories.common.TerritoryGeometrySyncPacket;
+import com.gdd.ptdyeplus.init.Packet;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TerritoryManager {
+    private final Set<ChunkPos> chunks = new HashSet<>();
+    private List<IslandGeometry> islandGeometries = Collections.emptyList();
+    private final UUID territoryId = UUID.randomUUID();
+
+    public void addChunk(ChunkPos pos) {
+        if (chunks.add(pos))
+            rebuildTerritoryGeometry();
+    }
+
+    public void addChunks(List<ChunkPos> chunks) {
+        boolean update = false;
+        for (ChunkPos pos : chunks)
+            update = chunks.add(pos) || update;
+        if (update)
+            rebuildTerritoryGeometry();
+    }
+
+    public void removeChunk(ChunkPos pos) {
+        if (chunks.remove(pos))
+            rebuildTerritoryGeometry();
+    }
+
+    public void removeChunks(List<ChunkPos> chunks) {
+        boolean update = false;
+        for (ChunkPos pos : chunks)
+            update = chunks.remove(pos) || update;
+        if (update)
+            rebuildTerritoryGeometry();
+    }
+
+    public void modifyChunks(List<ChunkPos> toAdd, List<ChunkPos> toRemove) {
+        boolean update = false;
+        for (ChunkPos pos : toAdd)
+            update = chunks.add(pos) || update;
+        for (ChunkPos pos : toRemove)
+            update = chunks.remove(pos) || update;
+        if (update)
+            rebuildTerritoryGeometry();
+    }
+
+    public void rebuildTerritoryGeometry() {
+        List<Set<ChunkPos>> islands = findIslands();
+        islandGeometries = rebuildPerimeters(islands);
+
+        Packet.CHANNEL.send(PacketDistributor.ALL.noArg(),
+            new TerritoryGeometrySyncPacket(territoryId, islandGeometries));
+    }
+
+    protected List<Set<ChunkPos>> findIslands() {
+        List<Set<ChunkPos>> islands = new ArrayList<>();
+        Set<ChunkPos> unvisited = new HashSet<>(chunks);
+
+        while (!unvisited.isEmpty()) {
+            Set<ChunkPos> island = new HashSet<>();
+            Queue<ChunkPos> queue = new LinkedList<>();
+            ChunkPos start = unvisited.iterator().next();
+            queue.add(start);
+            unvisited.remove(start);
+
+            while (!queue.isEmpty()) {
+                ChunkPos current = queue.poll();
+                island.add(current);
+                // Chunk 4 neighbors
+                ChunkPos[] neighbors = {
+                    new ChunkPos(current.x + 1, current.z),
+                    new ChunkPos(current.x - 1, current.z),
+                    new ChunkPos(current.x, current.z + 1),
+                    new ChunkPos(current.x, current.z - 1)
+                };
+                for (ChunkPos n : neighbors) {
+                    if (unvisited.contains(n)) {
+                        unvisited.remove(n);
+                        queue.add(n);
+                    }
+                }
+            }
+            islands.add(island);
+        }
+        return islands;
+    }
+
+    protected List<IslandGeometry> rebuildPerimeters(List<Set<ChunkPos>> islands) {
+        List<IslandGeometry> allGeometries = new ArrayList<>();
+
+        for (Set<ChunkPos> island : islands) {
+            Map<Edge, Integer> edgeCounts = new HashMap<>();
+            for (ChunkPos chunk : island) {
+                int minX = chunk.getMinBlockX();
+                int maxX = minX + 16; // getMaxBlockN, returns inclusive(+15), we want exclusive, so we add +16
+                int minZ = chunk.getMinBlockZ();
+                int maxZ = minZ + 16;
+
+                BlockPos nw = new BlockPos(minX, 0, minZ);
+                BlockPos ne = new BlockPos(maxX, 0, minZ);
+                BlockPos se = new BlockPos(maxX, 0, maxZ);
+                BlockPos sw = new BlockPos(minX, 0, maxZ);
+
+                addEdge(edgeCounts, new Edge(nw, ne));
+                addEdge(edgeCounts, new Edge(ne, se));
+                addEdge(edgeCounts, new Edge(se, sw));
+                addEdge(edgeCounts, new Edge(sw, nw));
+            }
+            List<Edge> boundaryEdges = edgeCounts.entrySet().stream()
+                .filter(e -> e.getValue() == 1)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+
+            List<List<BlockPos>> loops = extractLoops(boundaryEdges);
+
+            loops.replaceAll(this::simplify);
+
+            allGeometries.add(classifyHullAndHoles(loops));
+        }
+        return allGeometries;
+    }
+
+    protected void addEdge(Map<Edge, Integer> counts, Edge edge) {
+        counts.put(edge, counts.getOrDefault(edge, 0) + 1);
+    }
+
+    protected List<List<BlockPos>> extractLoops(List<Edge> edges) {
+        List<List<BlockPos>> loops = new ArrayList<>();
+
+        Map<BlockPos, List<Edge>> pointMap = new HashMap<>();
+        for (Edge e : edges) {
+            pointMap.computeIfAbsent(e.p1(), k -> new ArrayList<>()).add(e);
+            pointMap.computeIfAbsent(e.p2(), k -> new ArrayList<>()).add(e);
+        }
+
+        Set<Edge> unvisited = new HashSet<>(edges);
+        while (!unvisited.isEmpty()) {
+            List<BlockPos> currentLoop = new ArrayList<>();
+
+            // Pick any remaining edges to start a new loop
+            Edge startEdge = unvisited.iterator().next();
+            unvisited.remove(startEdge);
+
+            // Determine direction
+            BlockPos current = startEdge.p2();
+            currentLoop.add(startEdge.p1());
+            currentLoop.add(current);
+
+            while (true) {
+                List<Edge> neighbors = pointMap.get(current);
+                Edge nextEdge = null;
+
+                // Find the neighbor that is still unvisited
+                if (neighbors != null) {
+                    for (Edge e : neighbors) {
+                        if (unvisited.contains(e)) {
+                            nextEdge = e;
+                            break;
+                        }
+                    }
+                }
+
+                if (nextEdge == null)
+                    break; // Loop is closed
+
+                unvisited.remove(nextEdge);
+
+                // Move to next point
+                current = (nextEdge.p1().equals(current)) ? nextEdge.p2() : nextEdge.p1();
+                currentLoop.add(current);
+            }
+            if (currentLoop.get(0).equals(currentLoop.get(currentLoop.size() - 1))) {
+                currentLoop.remove(currentLoop.size() - 1);
+            }
+            loops.add(currentLoop);
+        }
+        return loops;
+    }
+
+    private IslandGeometry classifyHullAndHoles(List<List<BlockPos>> loops) {
+        if (loops.isEmpty())
+            return new IslandGeometry(Collections.emptyList(), null);
+
+        // The loop with the latest area is the outer hull
+        List<BlockPos> hull = loops.get(0);
+        double maxArea = getPolygonArea(hull);
+        for (int i = 1; i < loops.size(); i++) {
+            double area = getPolygonArea(loops.get(i));
+            if (area > maxArea) {
+                maxArea = area;
+                hull = loops.get(i);
+            }
+        }
+
+        // Everything else is a hole
+        List<List<BlockPos>> holes = new ArrayList<>(loops);
+        holes.remove(hull);
+
+        return new IslandGeometry(hull, holes.isEmpty() ? null : holes);
+    }
+
+    // Shoelace area
+    private double getPolygonArea(List<BlockPos> path) {
+        double area = 0.0;
+        int j = path.size() - 1;
+        for (int i = 0; i < path.size(); i++) {
+            BlockPos p1 = path.get(j);
+            BlockPos p2 = path.get(i);
+            area += (p1.getX() + p2.getX()) * (p1.getZ() - p2.getZ());
+            j = i;
+        }
+        return Math.abs(area / 2.0);
+    }
+
+    protected List<BlockPos> simplify(List<BlockPos> path) {
+        if (path.size() < 3)
+            return path;
+
+        List<BlockPos> simplified = new ArrayList<>();
+        for (int i = 0; i < path.size(); i++) {
+            BlockPos previous = path.get((i + path.size() - 1) % path.size());
+            BlockPos current = path.get(i);
+            BlockPos next = path.get((i + 1) % path.size());
+
+            boolean collinear = (previous.getX() == current.getX() && current.getX() == next.getX()) ||
+                (previous.getZ() == current.getZ() && current.getZ() == next.getZ());
+
+            if (!collinear) {
+                simplified.add(current);
+            }
+        }
+        return simplified;
+    }
+
+}

--- a/src/main/java/com/gdd/ptdyeplus/init/Packet.java
+++ b/src/main/java/com/gdd/ptdyeplus/init/Packet.java
@@ -2,6 +2,9 @@ package com.gdd.ptdyeplus.init;
 
 import com.gdd.ptdyeplus.PTDyePlus;
 import com.gdd.ptdyeplus.content.contraptions.IndependentContraptionEntity;
+import com.gdd.ptdyeplus.features.territories.client.TerritoryNetworkHandler;
+import com.gdd.ptdyeplus.features.territories.common.TerritoryGeometrySyncPacket;
+import com.gdd.ptdyeplus.features.territories.common.TerritoryStyleSyncPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkRegistry;
@@ -20,12 +23,27 @@ public class Packet {
 
     private static int id() {return packetId++;}
 
+    // NOTE: KEEP PACKET ORDER! add new messages from the bottom to keep compatibility
     public static void register() {
         // Independent_Contraption's packet
         CHANNEL.messageBuilder(IndependentContraptionEntity.IndependentContraptionControlPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
             .decoder(IndependentContraptionEntity.IndependentContraptionControlPacket::new)
             .encoder(IndependentContraptionEntity.IndependentContraptionControlPacket::write)
             .consumerMainThread(IndependentContraptionEntity.IndependentContraptionControlPacket::handle)
+            .add();
+
+        // Territory's geometry packet
+        CHANNEL.messageBuilder(TerritoryGeometrySyncPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
+            .decoder(TerritoryGeometrySyncPacket::decode)
+            .encoder(TerritoryGeometrySyncPacket::encode)
+            .consumerMainThread(TerritoryNetworkHandler::handleGeometry)
+            .add();
+
+        // Territory's style packet
+        CHANNEL.messageBuilder(TerritoryStyleSyncPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
+            .decoder(TerritoryStyleSyncPacket::decode)
+            .encoder(TerritoryStyleSyncPacket::encode)
+            .consumerMainThread(TerritoryNetworkHandler::handleStyle)
             .add();
     }
 }

--- a/src/main/java/com/gdd/ptdyeplus/journeymap/JMBridge.java
+++ b/src/main/java/com/gdd/ptdyeplus/journeymap/JMBridge.java
@@ -1,0 +1,33 @@
+package com.gdd.ptdyeplus.journeymap;
+
+import com.gdd.ptdyeplus.PTDyePlus;
+import com.gdd.ptdyeplus.features.territories.client.TerritoryNetworkHandler;
+import journeymap.client.api.ClientPlugin;
+import journeymap.client.api.IClientAPI;
+import journeymap.client.api.IClientPlugin;
+import journeymap.client.api.event.ClientEvent;
+
+@ClientPlugin
+@SuppressWarnings("unused")
+public class JMBridge implements IClientPlugin {
+    private static IClientAPI jmAPI = null;
+
+    public static IClientAPI getAPI() {
+        return jmAPI;
+    }
+
+    @Override
+    public void initialize(IClientAPI jmAPI) {
+        this.jmAPI = jmAPI;
+
+        TerritoryNetworkHandler.onAPIReady(jmAPI);
+    }
+
+    @Override
+    public String getModId() {
+        return PTDyePlus.ID;
+    }
+
+    @Override
+    public void onEvent(ClientEvent clientEvent) {}
+}

--- a/src/main/java/com/gdd/ptdyeplus/journeymap/TerritoryOverlay.java
+++ b/src/main/java/com/gdd/ptdyeplus/journeymap/TerritoryOverlay.java
@@ -1,6 +1,7 @@
 package com.gdd.ptdyeplus.journeymap;
 
 import com.gdd.ptdyeplus.PTDyePlus;
+import com.gdd.ptdyeplus.features.territories.client.TerritoryConverter;
 import com.gdd.ptdyeplus.features.territories.common.IslandGeometry;
 import journeymap.client.api.IClientAPI;
 import journeymap.client.api.display.PolygonOverlay;
@@ -66,7 +67,7 @@ public class TerritoryOverlay {
         overlays = new ArrayList<>();
         for (int i = 0; i < geometries.size(); i++) {
             IslandGeometry island = geometries.get(i);
-            MapPolygonWithHoles shape = island.toMapPolygon();
+            MapPolygonWithHoles shape = TerritoryConverter.toMapPolygon(island);
 
             PolygonOverlay overlay = new PolygonOverlay(
                 PTDyePlus.ID,

--- a/src/main/java/com/gdd/ptdyeplus/journeymap/TerritoryOverlay.java
+++ b/src/main/java/com/gdd/ptdyeplus/journeymap/TerritoryOverlay.java
@@ -28,11 +28,11 @@ public class TerritoryOverlay {
 
     private static ShapeProperties createDefaultProperties() {
         return new ShapeProperties()
-            .setFillColor(0xFF0000)
+            .setFillColor(0xFF0000) // RGB
             .setStrokeColor(0xFF0000)
-            .setStrokeOpacity(0.8f)
-            .setFillOpacity(0.6f)
-            .setStrokeWidth(1.5f);
+            .setStrokeOpacity(0.6f)
+            .setFillOpacity(0.2f)
+            .setStrokeWidth(3.0f); // Pixels (Doesn't scale with DPI)
     }
 
     public TerritoryOverlay(UUID territoryId) {

--- a/src/main/java/com/gdd/ptdyeplus/journeymap/TerritoryOverlay.java
+++ b/src/main/java/com/gdd/ptdyeplus/journeymap/TerritoryOverlay.java
@@ -1,0 +1,107 @@
+package com.gdd.ptdyeplus.journeymap;
+
+import com.gdd.ptdyeplus.PTDyePlus;
+import com.gdd.ptdyeplus.features.territories.common.IslandGeometry;
+import journeymap.client.api.IClientAPI;
+import journeymap.client.api.display.PolygonOverlay;
+import journeymap.client.api.model.MapPolygonWithHoles;
+import journeymap.client.api.model.ShapeProperties;
+import net.minecraft.world.level.Level;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+public class TerritoryOverlay {
+    private static IClientAPI jmAPI = null;
+
+    public static void updateAPI(IClientAPI jmAPI) {
+        TerritoryOverlay.jmAPI = jmAPI;
+    }
+
+    private final UUID territoryId;
+    private List<IslandGeometry> geometries = Collections.emptyList();
+    private List<PolygonOverlay> overlays = Collections.emptyList();
+    private ShapeProperties shapeProperties = TerritoryOverlay.createDefaultProperties();
+
+    private static ShapeProperties createDefaultProperties() {
+        return new ShapeProperties()
+            .setFillColor(0xFF0000)
+            .setStrokeColor(0xFF0000)
+            .setStrokeOpacity(0.8f)
+            .setFillOpacity(0.6f)
+            .setStrokeWidth(1.5f);
+    }
+
+    public TerritoryOverlay(UUID territoryId) {
+        this.territoryId = territoryId;
+    }
+
+    public UUID getTerritoryId() {
+        return territoryId;
+    }
+
+    public void updateGeometry(List<IslandGeometry> geometries) throws Exception {
+        this.geometries = geometries;
+        refreshOverlay();
+    }
+
+    public void updateStyle(ShapeProperties shapeProperties) throws Exception {
+        this.shapeProperties = shapeProperties;
+        if (jmAPI != null && !overlays.isEmpty()) {
+            for (PolygonOverlay overlay : overlays) {
+                overlay.setShapeProperties(this.shapeProperties);
+                jmAPI.show(overlay); // update overlay
+            }
+        }
+    }
+
+    public void refreshOverlay() throws Exception {
+        if (jmAPI == null)
+            return;
+        clear();
+        if (geometries.isEmpty())
+            return; // If geometries is empty; there are no overlays to add.
+        overlays = new ArrayList<>();
+        for (int i = 0; i < geometries.size(); i++) {
+            IslandGeometry island = geometries.get(i);
+            MapPolygonWithHoles shape = island.toMapPolygon();
+
+            PolygonOverlay overlay = new PolygonOverlay(
+                PTDyePlus.ID,
+                territoryId + "_" + i,
+                Level.OVERWORLD,
+                shapeProperties,
+                shape
+            );
+            overlays.add(overlay);
+        }
+        add();
+    }
+
+    private void clear() {
+        if (jmAPI == null) {
+            PTDyePlus.LOGGER.info("Tried to clear TerritoryOverlay's before jmAPI was initialized.");
+            return;
+        }
+        if (overlays.isEmpty())
+            return;
+        for (PolygonOverlay overlay : overlays) {
+            jmAPI.remove(overlay);
+        }
+        overlays = Collections.emptyList();
+    }
+
+    private void add() throws Exception {
+        if (jmAPI == null) {
+            PTDyePlus.LOGGER.info("Tried to add TerritoryOverlay's before jmAPI was initialized.");
+            return;
+        }
+        if (overlays.isEmpty())
+            return;
+        for (PolygonOverlay overlay : overlays) {
+            jmAPI.show(overlay);
+        }
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -79,6 +79,12 @@ mandatory = false
 versionRange = "[11.13.2,)"
 ordering = "AFTER"
 side = "CLIENT"
+[[dependencies.${mod_id}]]
+modId = "journeymap"
+mandatory = false
+versionRange = "[5.9.0,)"
+ordering = "NONE"
+side = "CLIENT"
 
 # Features are specific properties of the game environment, that you may want to declare you require. This example declares
 # that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't


### PR DESCRIPTION
Added the ability to mark chunks, or unmark them on the server; and then the change is distributed to clients with the journey mod installed. This change doesn't make the journey mod mandatory, it will work without the mod, but you won't see the chunk shading.

The design goal is that each team will have a single `TerritoryManager`, which is then used to display marked chunks. This system does not save anything, that is on the user of this class to handle persistence data. 